### PR TITLE
AutoUpdater progress display

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -48,7 +48,14 @@ ipcMain.on("check-for-updates", event => {
 
   autoUpdater.on("update-available", () => {
     event.sender.send("auto-updater-message", {
-      message: "update downloading..."
+      message: "Updates available. Starting download..."
+    });
+  });
+
+  autoUpdater.on("download-progress", progressInfo => {
+    const progressPercent = Math.round(progressInfo.percent);
+    event.sender.send("auto-updater-progress", {
+      message: `Update downloading ${progressPercent}%...`
     });
   });
 
@@ -61,8 +68,8 @@ ipcMain.on("check-for-updates", event => {
 
   autoUpdater.on("update-downloaded", () => {
     // trigger app to close and update install
-    event.sender.send("auto-updater-message", {
-      message: "installing update..."
+    event.sender.send("auto-updater-done", {
+      message: "Installing update..."
     });
     autoUpdater.quitAndInstall();
   });

--- a/src/components/Snackbar.vue
+++ b/src/components/Snackbar.vue
@@ -26,6 +26,13 @@ export default {
         this.timeout = state.snackbar.timeout;
         this.show = true;
       }
+      if (mutation.type === "snackbar/update") {
+        this.message = state.snackbar.content;
+      }
+      if (mutation.type === "snackbar/close") {
+        this.message = state.snackbar.content;
+        this.timeout = state.snackbar.timeout;
+      }
     });
   }
 };

--- a/src/plugins/snackbar.ts
+++ b/src/plugins/snackbar.ts
@@ -6,8 +6,18 @@ interface Flash {
   ({ content, color, timeout }: { content: string; color?: string; timeout?: number }): void;
 }
 
+interface Update {
+  ({ content }: { content: string }): void;
+}
+
+interface Close {
+  ({ content, timeout }: { content: string; timeout: number }): void;
+}
+
 declare type SnackbarPlugin = {
   flash: Flash;
+  update: Update;
+  close: Close;
 };
 
 declare module "vue/types/vue" {
@@ -24,6 +34,12 @@ const snackbarPlugin: PluginObject<any> = {
     Vue.prototype.$snackbar = {
       flash: function({ content = "", color = "info", timeout = 5000 }) {
         store.commit("snackbar/flash", { content, color, timeout }, { root: true });
+      },
+      update: function({ content = "" }) {
+        store.commit("snackbar/update", { content }, { root: false });
+      },
+      close: function({ content = "", timeout = 5000 }) {
+        store.commit("snackbar/close", { content, timeout }, { root: false });
       }
     };
   }

--- a/src/store/snackbar.ts
+++ b/src/store/snackbar.ts
@@ -18,6 +18,13 @@ export const mutations: MutationTree<ISnackbarState> = {
     state.content = payload.content;
     state.color = payload.color;
     state.timeout = payload.timeout;
+  },
+  update(state, payload) {
+    state.content = payload.content;
+  },
+  close(state, payload) {
+    state.content = payload.content;
+    state.timeout = payload.timeout;
   }
 };
 

--- a/src/views/auth/Login.vue
+++ b/src/views/auth/Login.vue
@@ -49,7 +49,16 @@ export default class Login extends Vue {
     ipcRenderer.send("check-for-updates");
     // wait for response
     ipcRenderer.on("auto-updater-message", (event, payload) => {
-      this.$snackbar.flash({ content: payload.message, color: "info", timeout: 2000 });
+      this.$snackbar.flash({ content: payload.message, color: "info", timeout: 3000 });
+    });
+    ipcRenderer.once("auto-updater-progress", (event, payload) => {
+      this.$snackbar.flash({ content: payload.message, color: "info", timeout: -1 });
+    });
+    ipcRenderer.on("auto-updater-progress", (event, payload) => {
+      this.$snackbar.update({ content: payload.message });
+    });
+    ipcRenderer.on("auto-updater-done", (event, payload) => {
+      this.$snackbar.close({ content: payload.message, timeout: 3000 });
     });
     ipcRenderer.once("update-not-available", () => {
       this.loading = false;


### PR DESCRIPTION
Implemented `update()` and `close()` methods and mutations on the snackbar component, added autoUpdater progress events on background and on login. Ended up going this way so that we use `flash()` with `timeout = -1` first, then we only update the content, and finally `close()` updates both content and the timeout so that it shows a finishing message. 

Update() could _update_ both content and timeout, so it could be used for both updating and closing the snackbar, but on each `autoUpdater.on("download-progress")` we would be overwriting `timeout = -1`. It wouldn't make much of a difference, but I thought this implementation could give us more flexibility for the snackbar in the future.

This should fix #98.